### PR TITLE
Fix bloodhound + update instructions + suggestions on Red day

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-Here you can find a Docker compose file to start all the required applications we will use throughout the Network Security course and its laboratory exercises.
+# 02233 - Network Security (2025)
+
+Here you can find a `docker-compose` file to start all the required services and applications we are going to use throughout the Network Security course and its laboratory exercises.
+
+First, compose up the containers.
+
+For the kali environment, open `https://localhost:6901/` in your browser, and continue with credentials:
+
+```sh
+User : kasm_user
+Password: password
+```
+
+To use `bloodhound`, you have to start the `neo4j` service:
+
+```sh
+sudo neo4j start
+```

--- a/kali.Dockerfile
+++ b/kali.Dockerfile
@@ -12,11 +12,9 @@ RUN mkdir material
 COPY material material
 
 RUN apt-get update \
-    && apt-get install -y sudo \
+    && apt-get install -y sudo bloodhound \
     && echo 'kasm-user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
-    && rm -rf /var/lib/apt/list/*
-
-RUN sudo apt-get install -y bloodhound
+    && rm -rf /var/lib/apt/lists/*
 
 ######### End Customizations ###########
 

--- a/material/11 - Red team/README.md
+++ b/material/11 - Red team/README.md
@@ -1,0 +1,20 @@
+# Red Team
+
+## Juice Shop
+
+Juice shop is available via the `juice-shop` service at `3000`. Go to root directory and `docker compose up`.
+
+## Portswigger
+
+List of recommended labs from Portswigger. The following labs are beginner friendly. In order to access the labs, you need to create an account.
+
+- [LLM API exploitation](https://portswigger.net/web-security/llm-attacks/lab-exploiting-llm-apis-with-excessive-agency)
+- [Lab HTML Context nothing encoded (Reflected)](https://portswigger.net/web-security/cross-site-scripting/reflected/lab-html-context-nothing-encoded)
+- [Lab HTML Context nothing encoded (Stored)](https://portswigger.net/web-security/cross-site-scripting/stored/lab-html-context-nothing-encoded)
+- [SQL Injection](https://portswigger.net/web-security/sql-injection/lab-retrieve-hidden-data)
+- [CSRF - No defenses](https://portswigger.net/web-security/csrf/lab-no-defenses)
+- [CSRF - Protected](https://portswigger.net/web-security/clickjacking/lab-basic-csrf-protected)
+- [Origin Reflection Attack](https://portswigger.net/web-security/cors/lab-basic-origin-reflection-attack)
+- [SSRF Basic](https://portswigger.net/web-security/ssrf/lab-basic-ssrf-against-localhost)
+- [File Path Traversal](https://portswigger.net/web-security/file-path-traversal/lab-simple)
+- [2FA Simple Bypass](https://portswigger.net/web-security/authentication/multi-factor/lab-2fa-simple-bypass)


### PR DESCRIPTION
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R18): Updated the course title, added instructions for starting services and applications, and provided details for accessing the kali environment and using `bloodhound`.

* [`kali.Dockerfile`](diffhunk://#diff-c331f9a14d83c263017d88114226c43fd01076c41bea5b40cad8b6ea1dae89fdL15-R17): Combined the installation of `bloodhound` with other packages to reduce the number of `RUN` commands and fixed a typo in the path cleanup command.

* [`material/11 - Red team/README.md`](diffhunk://#diff-82c955e11b9a537bd4e27430fee487aefb6335729b819de3dd33420afb4b73f6R1-R20): Added a new section for the Red Team, including instructions for accessing Juice Shop and a list of recommended labs from Portswigger.