### PR TITLE
fix: added platform to kali and defender images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@
 services:
   kali:
     image: ryaben/kali-dtunetsec:latest
+    platform: linux/amd64
     ports:
       - "6901:6901"
     environment:
@@ -12,6 +13,7 @@ services:
 
   defender:
     image: ryaben/defender-dtunetsec:latest
+    platform: linux/amd64
     ports:
       - "2223:22"
       - "8080:80"


### PR DESCRIPTION
I was getting an error: `no matching manifest for linux/arm64/v8 in the manifest list entries` when using `docker compose up -d --build kali defender`. Looks like I just needed to add platform to the `kali` and `defender` images and it works!