### PR TITLE
made script executable and updated shebang

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Default values
 LOCAL=false


### PR DESCRIPTION
Run script was not executable and did not work with './run.sh'.
The shebang '#!/bin/bash' is outdated and does not work on my system for example. I changed the shebang to a more modern standard.