### PR TITLE
dnscat2 support

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -2,8 +2,8 @@ name: ci
 
 on:
   push:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "build/*.Dockerfile"
     branches:
       - "main"
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Threat Detection | threat-detection
 Blue Team | blue-team
 IoT Security | iot
 WIFI Security | wifi
+Privacy | privacy
 Red Team | red-team
 
 <p>Table 1: Lab names and codes to run containers </p>

--- a/README.md
+++ b/README.md
@@ -75,3 +75,9 @@ The codes for each lab are shown in Table 1.
     > ```sh
     > sudo -E wireshark
     > ```
+    
+    > **NOTE 3:** to run `dnscat` server in `kali`, you need to run: 
+    > ```sh
+    > ruby material/dnscat2/server/dnscat2.rb <args>
+    > ```
+    

--- a/build/defender.Dockerfile
+++ b/build/defender.Dockerfile
@@ -20,6 +20,8 @@ RUN apk add --no-cache \
   php php-apache2 php-common php-session \
   # Supervisor
   supervisor \
+  # dnscat
+  build-base \
   && rm -rf /var/cache/apk/*
 
 RUN curl -L https://github.com/CISOfy/lynis/archive/refs/heads/master.tar.gz -o lynis.tar.gz && \
@@ -46,6 +48,14 @@ RUN sed -i -e "s/^nodaemon=false/nodaemon=true/" /etc/supervisor/supervisord.con
 ADD containers/defender/supervisor/ /etc/supervisor/conf.d/
 RUN echo "[include]" >> /etc/supervisor/supervisord.conf
 RUN echo "files=/etc/supervisor/conf.d/*.conf" >> /etc/supervisor/supervisord.conf
+
+# dnscat
+RUN curl -L https://github.com/iagox86/dnscat2/archive/refs/heads/master.tar.gz -o dnscat2.tar.gz && \
+tar -xzvf dnscat2.tar.gz && rm dnscat2.tar.gz
+WORKDIR dnscat2-master
+RUN make
+RUN sudo ln -s /dnscat2-master/client/dnscat /usr/local/bin/dnscat2-client
+WORKDIR /
 
 # Expose ports (Note: this does nothing)
 EXPOSE 22 80

--- a/build/kali.Dockerfile
+++ b/build/kali.Dockerfile
@@ -9,12 +9,20 @@ WORKDIR $HOME
 RUN apt update && apt install -y --no-install-recommends \
     build-essential libssl-dev libffi-dev python3-dev python3-pip python3-venv git \
     evil-winrm iputils-ping ftp \
+    ruby-dev \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Copy material
 COPY --chown=1000:0 containers/kali/material material
 RUN tar -xzvf material/2-Authentication/impacket-cve-2020-1472.tar.gz -C material/2-Authentication/ \
     && rm material/2-Authentication/impacket-cve-2020-1472.tar.gz
+
+WORKDIR material
+# Add dnscat-2
+RUN curl -L https://github.com/iagox86/dnscat2/archive/refs/heads/master.tar.gz -o dnscat2.tar.gz && \
+tar -xzvf dnscat2.tar.gz && rm dnscat2.tar.gz
+WORKDIR dnscat2-master/server
+RUN bundle install
 
 # Add user sudo privileges
 RUN echo 'kasm-user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
@@ -25,6 +33,7 @@ RUN $STARTUPDIR/set_user_permission.sh $HOME
 
 # Final user setup
 ENV HOME=/home/kasm-user
+
 WORKDIR $HOME
 RUN mkdir -p $HOME && chown -R 1000:0 $HOME
 

--- a/build/kali.Dockerfile
+++ b/build/kali.Dockerfile
@@ -9,7 +9,6 @@ WORKDIR $HOME
 RUN apt update && apt install -y --no-install-recommends \
     build-essential libssl-dev libffi-dev python3-dev python3-pip python3-venv git \
     evil-winrm iputils-ping ftp \
-    dnscat2-server \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Copy material

--- a/build/kali.Dockerfile
+++ b/build/kali.Dockerfile
@@ -9,6 +9,7 @@ WORKDIR $HOME
 RUN apt update && apt install -y --no-install-recommends \
     build-essential libssl-dev libffi-dev python3-dev python3-pip python3-venv git \
     evil-winrm iputils-ping ftp \
+    dnscat2-server \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Copy material

--- a/build/kali.Dockerfile
+++ b/build/kali.Dockerfile
@@ -17,11 +17,13 @@ COPY --chown=1000:0 containers/kali/material material
 RUN tar -xzvf material/2-Authentication/impacket-cve-2020-1472.tar.gz -C material/2-Authentication/ \
     && rm material/2-Authentication/impacket-cve-2020-1472.tar.gz
 
-WORKDIR material
 # Add dnscat-2
-RUN curl -L https://github.com/iagox86/dnscat2/archive/refs/heads/master.tar.gz -o dnscat2.tar.gz && \
-tar -xzvf dnscat2.tar.gz && rm dnscat2.tar.gz
-WORKDIR dnscat2-master/server
+WORKDIR material
+RUN curl -L https://github.com/iagox86/dnscat2/archive/refs/heads/master.tar.gz -o dnscat2.tar.gz \
+    && tar -xzvf dnscat2.tar.gz \
+    && rm dnscat2.tar.gz \
+    && mv dnscat2-master dnscat2
+WORKDIR dnscat2/server
 RUN bundle install
 
 # Add user sudo privileges

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
   kali:
     image: ryaben/kali-dtunetsec:latest
     platform: linux/amd64
-    profiles: [bootcamp]
     ports:
       - "127.0.0.1:6901:6901"
     environment:
@@ -15,7 +14,7 @@ services:
   defender:
     image: ryaben/defender-dtunetsec:latest
     platform: linux/amd64
-    profiles: [threat-detection, authentication, blue-team]
+    profiles: [threat-detection, authentication, blue-team, privacy]
     privileged: true
     cap_add:
       - NET_ADMIN

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
   kali:
     image: ryaben/kali-dtunetsec:latest
     platform: linux/amd64
+    profiles: [bootcamp]
     ports:
       - "127.0.0.1:6901:6901"
     environment:


### PR DESCRIPTION
This pull request includes several changes to Docker-related files and documentation to add support for `dnscat2` and improve the CI workflow. The most important changes include updates to Dockerfiles for `defender` and `kali`, modifications to the CI workflow, and updates to the documentation.

### Dockerfile updates:

* [`build/defender.Dockerfile`](diffhunk://#diff-14a5b836e9671ca08e024783f8165918e02d4da4e467d7f8fea65debd655a667R23-R24): Added installation steps for `dnscat2` by downloading, extracting, and building the source code. [[1]](diffhunk://#diff-14a5b836e9671ca08e024783f8165918e02d4da4e467d7f8fea65debd655a667R23-R24) [[2]](diffhunk://#diff-14a5b836e9671ca08e024783f8165918e02d4da4e467d7f8fea65debd655a667R52-R59)
* [`build/kali.Dockerfile`](diffhunk://#diff-53e7d5433b046f1f04c02660fa542ccece3a7552148a130d588b5c0c0388289cR12-R28): Added `ruby-dev` package and steps to download, extract, and set up `dnscat2` server. [[1]](diffhunk://#diff-53e7d5433b046f1f04c02660fa542ccece3a7552148a130d588b5c0c0388289cR12-R28) [[2]](diffhunk://#diff-53e7d5433b046f1f04c02660fa542ccece3a7552148a130d588b5c0c0388289cR38)

### CI workflow updates:

* [`.github/workflows/docker-images.yaml`](diffhunk://#diff-dfbead86adb7542e8d247e4a8b97e214d517a61bb30c729943529847c88639d2L5-R6): Modified the CI workflow to trigger on changes to Dockerfiles in the `build` directory.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R78-R83): Added a note on how to run the `dnscat` server in `kali`.

### Docker Compose updates:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R6): Added `profiles: [bootcamp]` to the `kali` service configuration.